### PR TITLE
Apply several changes that was needed to run on GKE

### DIFF
--- a/test-distribution-kubedock.yaml
+++ b/test-distribution-kubedock.yaml
@@ -79,7 +79,7 @@ spec:
       terminationGracePeriodSeconds: 600
       containers:
         - name: kubedock
-          image: joyrex2001/kubedock:0.16.0
+          image: joyrex2001/kubedock:0.17.0
           args:
             - server
             - --reverse-proxy

--- a/test-distribution-kubedock.yaml
+++ b/test-distribution-kubedock.yaml
@@ -88,6 +88,8 @@ spec:
           volumeMounts:
             - name: kubedock-socket
               mountPath: /var/run
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
         - name: test-distribution-agent
           image: gradle/develocity-test-distribution-agent
           resources:
@@ -116,4 +118,6 @@ spec:
               mountPath: /var/run
       volumes:
         - name: kubedock-socket
+          emptyDir: { }
+        - name: postgres-storage
           emptyDir: { }


### PR DESCRIPTION
Hello, 👋 

I'm trying to apply `kubedock` to run Develocity on GKE, and this example helped me a lot!
Thanks for sharing this example on GitHub.

During my trial, I found several updates that was needed to run on GKE:

1. Simply update `kubedock` to the latest release, to reduce the risk to face known issues.
2. Mount a storage to `kubedock` to avoid `initdb: could not change permissions of directory "/var/lib/postgresql/data/pgdata"` error

It was also necessary to add `resources` to the `kubedock` container, but I don't include this change to PR because I'm unsure which value I should use for this example.

This PR suggests to add these two updates, hope that it helps you to keep this example useful and updated. Thanks for checking this PR!